### PR TITLE
Refine the logic for Android SafetyNet attestation, even though the format is deprecated

### DIFF
--- a/src/Shark.Fido2.Core/Abstractions/Services/IAndroidSafetyNetJwsResponseParserService.cs
+++ b/src/Shark.Fido2.Core/Abstractions/Services/IAndroidSafetyNetJwsResponseParserService.cs
@@ -2,7 +2,15 @@
 
 namespace Shark.Fido2.Core.Abstractions.Services;
 
+/// <summary>
+/// Parses Android SafetyNet JWS (JSON Web Signature) responses.
+/// </summary>
 public interface IAndroidSafetyNetJwsResponseParserService
 {
+    /// <summary>
+    /// Parses the given byte array containing a SafetyNet JWS response.
+    /// </summary>
+    /// <param name="response">The byte array representation of the JWS response.</param>
+    /// <returns>The <see cref="JwsResponse"/> object if parsing is successful; otherwise, <c>null</c>.</returns>
     JwsResponse? Parse(byte[] response);
 }

--- a/src/Shark.Fido2.Core/Services/AndroidSafetyNetJwsResponseParserService.cs
+++ b/src/Shark.Fido2.Core/Services/AndroidSafetyNetJwsResponseParserService.cs
@@ -25,6 +25,7 @@ internal sealed class AndroidSafetyNetJwsResponseParserService : IAndroidSafetyN
     {
         ArgumentNullException.ThrowIfNull(response);
 
+        // Response is the UTF-8 encoded result of the getJwsResult() call of the SafetyNet API.
         var jwsResponse = Encoding.UTF8.GetString(response);
 
         if (string.IsNullOrWhiteSpace(jwsResponse))
@@ -42,9 +43,9 @@ internal sealed class AndroidSafetyNetJwsResponseParserService : IAndroidSafetyN
 
         var certificates = new List<object>();
         if (jwtToken.Header.TryGetValue(AttestationStatement.Certificate, out var x5c) &&
-            x5c is List<object>)
+            x5c is List<object> x5cList)
         {
-            certificates.AddRange((List<object>)x5c);
+            certificates.AddRange(x5cList);
         }
 
         var nonce = GetClaim(jwtToken.Claims, ClaimTypeNonce);

--- a/src/Shark.Fido2.Core/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategy.cs
+++ b/src/Shark.Fido2.Core/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategy.cs
@@ -59,20 +59,20 @@ internal class AndroidSafetyNetAttestationStatementStrategy : IAttestationStatem
         // SafetyNet online documentation. As of this writing, there is only one format of the SafetyNet response and
         // ver is reserved for future use.
         if (!attestationStatementDict.TryGetValue(AttestationStatement.Version, out var version) ||
-            version is not string)
+            version is not string versionString || string.IsNullOrWhiteSpace(versionString))
         {
             return ValidatorInternalResult.Invalid(
                 "Android SafetyNet attestation statement version is missing or invalid");
         }
 
         if (!attestationStatementDict.TryGetValue(AttestationStatement.Response, out var response) ||
-            response is not byte[])
+            response is not byte[] responseBytes || responseBytes.Length == 0)
         {
             return ValidatorInternalResult.Invalid(
                 "Android SafetyNet attestation statement response is missing or invalid");
         }
 
-        var jwsResponse = _jwsResponseParserService.Parse((byte[])response);
+        var jwsResponse = _jwsResponseParserService.Parse(responseBytes);
         if (jwsResponse == null)
         {
             return ValidatorInternalResult.Invalid(

--- a/src/Shark.Fido2.Core/Validators/AttestationStatementValidators/AttestationCertificateValidator.cs
+++ b/src/Shark.Fido2.Core/Validators/AttestationStatementValidators/AttestationCertificateValidator.cs
@@ -312,7 +312,7 @@ internal class AttestationCertificateValidator : IAttestationCertificateValidato
 
         const string Prefix = "Android SafetyNet attestation statement";
 
-        if (certificates.Count < 2)
+        if (certificates.Count == 1)
         {
             return ValidatorInternalResult.Invalid($"{Prefix} self-signed certificate is not supported");
         }

--- a/tests/Shark.Fido2.Core.Tests/Shark.Fido2.Core.Tests.csproj
+++ b/tests/Shark.Fido2.Core.Tests/Shark.Fido2.Core.Tests.csproj
@@ -78,6 +78,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidKeyAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidKeyAttestationStatementStrategyTests.cs
@@ -16,10 +16,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class AndroidKeyAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _provider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _provider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private AndroidKeyAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategyTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Shark.Fido2.Core.Abstractions.Validators;
 using Shark.Fido2.Core.Handlers;
@@ -42,7 +43,8 @@ internal class AndroidSafetyNetAttestationStatementStrategyTests
 
         var jwsResponseParserService = new AndroidSafetyNetJwsResponseParserService();
 
-        var jwsResponseValidator = new AndroidSafetyNetJwsResponseValidator();
+        var fakeTimeProvider = new FakeTimeProvider();
+        var jwsResponseValidator = new AndroidSafetyNetJwsResponseValidator(fakeTimeProvider);
 
         var attestationCertificateProviderService = new AttestationCertificateProviderService();
 
@@ -60,7 +62,7 @@ internal class AndroidSafetyNetAttestationStatementStrategyTests
             attestationCertificateValidator);
     }
 
-    [Ignore("Valid Android Safety Net attestation to be generated")]
+    [Ignore("The Android SafetyNet Attestation API was deprecated in 2022 and fully turned down in January 2025")]
     [Test]
     public async Task Validate_WhenAndroidSafetyNetAttestationWithRs256Algorithm_ThenValidates()
     {

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AndroidSafetyNetAttestationStatementStrategyTests.cs
@@ -16,10 +16,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class AndroidSafetyNetAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _provider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _provider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private AndroidSafetyNetAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AppleAnonymousAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/AppleAnonymousAttestationStatementStrategyTests.cs
@@ -15,10 +15,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class AppleAnonymousAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _provider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _provider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private AppleAnonymousAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/FidoU2fAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/FidoU2fAttestationStatementStrategyTests.cs
@@ -16,10 +16,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class FidoU2FAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _provider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _provider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private FidoU2FAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/NoneAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/NoneAttestationStatementStrategyTests.cs
@@ -14,10 +14,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class NoneAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _provider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _provider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private NoneAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/PackedAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/PackedAttestationStatementStrategyTests.cs
@@ -16,10 +16,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class PackedAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _authenticatorDataProvider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _authenticatorDataProvider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private PackedAttestationStatementStrategy _sut = null!;
 

--- a/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/TpmAttestationStatementStrategyTests.cs
+++ b/tests/Shark.Fido2.Core.Tests/Validators/AttestationStatementValidators/TpmAttestationStatementStrategyTests.cs
@@ -16,10 +16,10 @@ namespace Shark.Fido2.Core.Tests.Validators.AttestationStatementValidators;
 [TestFixture]
 internal class TpmAttestationStatementStrategyTests
 {
-    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock;
-    private AttestationObjectHandler _attestationObjectHandler;
-    private AuthenticatorDataParserService _authenticatorDataProvider;
-    private PublicKeyCredentialCreationOptions _creationOptions;
+    private Mock<IAttestationObjectValidator> _attestationObjectValidatorMock = null!;
+    private AttestationObjectHandler _attestationObjectHandler = null!;
+    private AuthenticatorDataParserService _authenticatorDataProvider = null!;
+    private PublicKeyCredentialCreationOptions _creationOptions = null!;
 
     private TpmAttestationStatementStrategy _sut = null!;
 


### PR DESCRIPTION
Refine the logic for Android SafetyNet attestation, even though the format is deprecated