### PR TITLE
Ignore CA1861 rule in unit tests for metadata service

### DIFF
--- a/tests/Shark.Fido2.Metadata.Core.Tests/Models/MetadataBlobPayloadEntryTests.cs
+++ b/tests/Shark.Fido2.Metadata.Core.Tests/Models/MetadataBlobPayloadEntryTests.cs
@@ -7,6 +7,7 @@ namespace Shark.Fido2.Metadata.Core.Tests.Models;
 internal class MetadataBlobPayloadEntryTests
 {
     [Test]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "For improved unit test readability")]
     public void DeserializeWindowsHelloHardwareAuthenticator_ShouldDeserializeCorrectly()
     {
         // Arrange


### PR DESCRIPTION
Ignore CA1861 rule in unit tests for metadata service